### PR TITLE
fix: supply all needed env to container for golang pipeline

### DIFF
--- a/.github/workflows/common-golang-ci.yml
+++ b/.github/workflows/common-golang-ci.yml
@@ -10,9 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # TODO: create renovate rule to bump SHA and use it instead of stable tag
-#      image: icr.io/goldeneye_images/goldeneye-ci-image:@sha256:354d7923003d2bff782f4b70b3563596185851c6e48ca9fd278fe8f32e395f88
+      #      image: icr.io/goldeneye_images/goldeneye-ci-image:@sha256:354d7923003d2bff782f4b70b3563596185851c6e48ca9fd278fe8f32e395f88
       image: icr.io/goldeneye_images/goldeneye-ci-image:stable
       env:
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
         NO_CONTAINER: "true"
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -27,8 +28,6 @@ jobs:
 
       # Check for pre-commit updates if it is a renovate PR
       - name: Renovate pre-commit sweeper
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           # Setup environment since GHA does not run the containers entrypoint
           . /root/.bashrc


### PR DESCRIPTION
Set all needed environment variables for golang CI steps to the main container, instead of in individual steps