### PR TITLE
fix: fix the format of the docker image tag

### DIFF
--- a/.github/workflows/common-release.yml
+++ b/.github/workflows/common-release.yml
@@ -14,7 +14,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     container:
-      image: icr.io/goldeneye_images/goldeneye-ci-image:@sha256:fb1b364d944e00d9cd7c21f524aab66230562843c6feb3e95a98fe263894fe3e
+      image: icr.io/goldeneye_images/goldeneye-ci-image@sha256:cfb3ad67d5b77d68c79150fc9b2ed441b42ac056a2f04bd0ad920873bf7eaf04
       env:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
         NO_CONTAINER: "true" # set so any Makefile actions will not run in new container

--- a/.github/workflows/common-terraform-module-ci.yml
+++ b/.github/workflows/common-terraform-module-ci.yml
@@ -12,7 +12,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: icr.io/goldeneye_images/goldeneye-ci-image:@sha256:fb1b364d944e00d9cd7c21f524aab66230562843c6feb3e95a98fe263894fe3e
+      image: icr.io/goldeneye_images/goldeneye-ci-image@sha256:cfb3ad67d5b77d68c79150fc9b2ed441b42ac056a2f04bd0ad920873bf7eaf04
       env:
         TF_VAR_ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
         IC_API_KEY: ${{ secrets.IBMCLOUD_API_KEY }}


### PR DESCRIPTION
### Description

fix the format of the docker image tag, as current format is incorrect, and gives error:
```
 /usr/bin/docker pull icr.io/goldeneye_images/goldeneye-ci-image:@sha256:fb1b364d944e00d9cd7c21f524aab66230562843c6feb3e95a98fe263894fe3e
  invalid reference format
  Warning: Docker pull failed with exit code 1, back off 7.353 seconds before retry.
```

**Check the relevant boxes:**
- [x] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
