### PR TITLE
ci: update renovate rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>terraform-ibm-modules/common-dev-assets:commonRenovateConfig"],
-  "group": true,
-  "groupName": "all",
   "regexManagers": [
     {
       "fileMatch": ["^.github/workflows/.*.yml$"],


### PR DESCRIPTION
### Description

renovate is incorrectly set up to group all changes into one PR. This is not what we want, so removing those flags

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
