### PR TITLE
fix(deps): update icr.io/goldeneye_images/goldeneye-ci-image digest

### DIFF
--- a/.github/workflows/common-golang-ci.yml
+++ b/.github/workflows/common-golang-ci.yml
@@ -9,7 +9,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     container:
-      image: icr.io/goldeneye_images/goldeneye-ci-image@sha256:636903044597ec91306945e6ed451227809d08bf88b57af45a898788e8442e75
+      image: icr.io/goldeneye_images/goldeneye-ci-image@sha256:df387a9c594616ae2d3e9022e0c24caaed0c7e8b97c35f1748c3986e27b3d929
       env:
         NO_CONTAINER: "true"
 

--- a/.github/workflows/common-golang-ci.yml
+++ b/.github/workflows/common-golang-ci.yml
@@ -9,7 +9,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     container:
-      image: icr.io/goldeneye_images/goldeneye-ci-image@sha256:17225eb04fdfd309d3d9a973992ac4400dcced9ee7d9e3fdd7fb76362b453c85
+      image: icr.io/goldeneye_images/goldeneye-ci-image@sha256:636903044597ec91306945e6ed451227809d08bf88b57af45a898788e8442e75
       env:
         NO_CONTAINER: "true"
 

--- a/.github/workflows/common-release.yml
+++ b/.github/workflows/common-release.yml
@@ -14,7 +14,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     container:
-      image: icr.io/goldeneye_images/goldeneye-ci-image@sha256:17225eb04fdfd309d3d9a973992ac4400dcced9ee7d9e3fdd7fb76362b453c85
+      image: icr.io/goldeneye_images/goldeneye-ci-image@sha256:636903044597ec91306945e6ed451227809d08bf88b57af45a898788e8442e75
       env:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
         NO_CONTAINER: "true" # set so any Makefile actions will not run in new container

--- a/.github/workflows/common-release.yml
+++ b/.github/workflows/common-release.yml
@@ -14,7 +14,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     container:
-      image: icr.io/goldeneye_images/goldeneye-ci-image@sha256:636903044597ec91306945e6ed451227809d08bf88b57af45a898788e8442e75
+      image: icr.io/goldeneye_images/goldeneye-ci-image@sha256:df387a9c594616ae2d3e9022e0c24caaed0c7e8b97c35f1748c3986e27b3d929
       env:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
         NO_CONTAINER: "true" # set so any Makefile actions will not run in new container

--- a/.github/workflows/common-terraform-module-ci.yml
+++ b/.github/workflows/common-terraform-module-ci.yml
@@ -13,7 +13,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: icr.io/goldeneye_images/goldeneye-ci-image@sha256:636903044597ec91306945e6ed451227809d08bf88b57af45a898788e8442e75
+      image: icr.io/goldeneye_images/goldeneye-ci-image@sha256:df387a9c594616ae2d3e9022e0c24caaed0c7e8b97c35f1748c3986e27b3d929
       env:
         TF_VAR_ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
         IC_API_KEY: ${{ secrets.IBMCLOUD_API_KEY }}

--- a/.github/workflows/common-terraform-module-ci.yml
+++ b/.github/workflows/common-terraform-module-ci.yml
@@ -13,7 +13,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: icr.io/goldeneye_images/goldeneye-ci-image@sha256:17225eb04fdfd309d3d9a973992ac4400dcced9ee7d9e3fdd7fb76362b453c85
+      image: icr.io/goldeneye_images/goldeneye-ci-image@sha256:636903044597ec91306945e6ed451227809d08bf88b57af45a898788e8442e75
       env:
         TF_VAR_ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
         IC_API_KEY: ${{ secrets.IBMCLOUD_API_KEY }}


### PR DESCRIPTION
### Description

Need to manually bump the image sha to pull in the latest image which has the `terraform-config-inspect` binary in it

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
