### PR TITLE
feat: expose CATALOG_PUBLISH_APIKEY and CATALOG_VALIDATION_APIKEY vars in common release pipeline

### DIFF
--- a/.github/workflows/common-release.yml
+++ b/.github/workflows/common-release.yml
@@ -20,6 +20,8 @@ jobs:
         NO_CONTAINER: "true" # set so any Makefile actions will not run in new container
         CATALOG_TEKTON_WEBHOOK_TOKEN: ${{ secrets.CATALOG_TEKTON_WEBHOOK_TOKEN }}
         CATALOG_TEKTON_WEBHOOK_URL: ${{ secrets.CATALOG_TEKTON_WEBHOOK_URL }}
+        CATALOG_PUBLISH_APIKEY: ${{ secrets.CATALOG_PUBLISH_APIKEY }}
+        CATALOG_VALIDATION_APIKEY: ${{ secrets.CATALOG_VALIDATION_APIKEY }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
### Description

feat: expose `CATALOG_PUBLISH_APIKEY` and `CATALOG_VALIDATION_APIKEY` vars in common release pipeline so they could be passed as part of tekton catalog pipeline webhook

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
