### PR TITLE
feat: install exact dependency versions during common pipeline execution

### DIFF
--- a/.github/workflows/common-golang-ci.yml
+++ b/.github/workflows/common-golang-ci.yml
@@ -23,6 +23,14 @@ jobs:
           # Clone all branches and history. This is needed for the upgrade tests
           fetch-depth: 0
 
+      # Install dependencies
+      - name: Install dependencies
+        run: |
+          # Setup environment since GHA does not run the containers entrypoint
+          . /root/.bashrc
+          . /root/.profile
+          make
+
       # Check for pre-commit updates if it is a renovate PR
       - name: Renovate sweeper
         env:

--- a/.github/workflows/common-golang-ci.yml
+++ b/.github/workflows/common-golang-ci.yml
@@ -9,7 +9,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     container:
-      image: icr.io/goldeneye_images/goldeneye-ci-image@sha256:d25f3360948940748d7139c39c5a9969a06cfc06817ada0675f186057ead93ce
+      image: icr.io/goldeneye_images/goldeneye-ci-image:stable
       env:
         NO_CONTAINER: "true"
 

--- a/.github/workflows/common-golang-ci.yml
+++ b/.github/workflows/common-golang-ci.yml
@@ -29,7 +29,7 @@ jobs:
           # Setup environment since GHA does not run the containers entrypoint
           . /root/.bashrc
           . /root/.profile
-          make
+          make dependency-install-darwin-linux
 
       # Check for pre-commit updates if it is a renovate PR
       - name: Renovate sweeper

--- a/.github/workflows/common-release.yml
+++ b/.github/workflows/common-release.yml
@@ -14,7 +14,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     container:
-      image: icr.io/goldeneye_images/goldeneye-ci-image@sha256:d25f3360948940748d7139c39c5a9969a06cfc06817ada0675f186057ead93ce
+      image: icr.io/goldeneye_images/goldeneye-ci-image:stable
       env:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
         NO_CONTAINER: "true" # set so any Makefile actions will not run in new container

--- a/.github/workflows/common-terraform-module-ci.yml
+++ b/.github/workflows/common-terraform-module-ci.yml
@@ -32,7 +32,11 @@ jobs:
 
       # Install dependencies
       - name: Install dependencies
-        run: make
+        run: |
+          # Setup environment since GHA does not run the containers entrypoint
+          . /root/.bashrc
+          . /root/.profile
+          make
 
       # Check for pre-commit updates if it is a renovate PR
       - name: Renovate sweeper
@@ -73,7 +77,11 @@ jobs:
 
       # Install dependencies
       - name: Install dependencies
-        run: make
+        run: |
+          # Setup environment since GHA does not run the containers entrypoint
+          . /root/.bashrc
+          . /root/.profile
+          make
 
       # run unit tests
       - name: Unit Tests

--- a/.github/workflows/common-terraform-module-ci.yml
+++ b/.github/workflows/common-terraform-module-ci.yml
@@ -13,7 +13,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: icr.io/goldeneye_images/goldeneye-ci-image@sha256:d25f3360948940748d7139c39c5a9969a06cfc06817ada0675f186057ead93ce
+      image: icr.io/goldeneye_images/goldeneye-ci-image@sha256:stable
       env:
         TF_VAR_ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
         IC_API_KEY: ${{ secrets.IBMCLOUD_API_KEY }}
@@ -29,6 +29,10 @@ jobs:
           submodules: true
           # Clone all branches and history. This is needed for the upgrade tests
           fetch-depth: 0
+
+      # Install dependencies
+      - name: Install dependencies
+        run: make
 
       # Check for pre-commit updates if it is a renovate PR
       - name: Renovate sweeper
@@ -53,7 +57,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: icr.io/goldeneye_images/goldeneye-ci-image@sha256:d25f3360948940748d7139c39c5a9969a06cfc06817ada0675f186057ead93ce
+      image: icr.io/goldeneye_images/goldeneye-ci-image@sha256:stable
       env:
         TF_VAR_ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
         IC_API_KEY: ${{ secrets.IBMCLOUD_API_KEY }}
@@ -66,6 +70,10 @@ jobs:
           submodules: true
           # Clone all branches and history. This is needed for the upgrade tests
           fetch-depth: 0
+
+      # Install dependencies
+      - name: Install dependencies
+        run: make
 
       # run unit tests
       - name: Unit Tests

--- a/.github/workflows/common-terraform-module-ci.yml
+++ b/.github/workflows/common-terraform-module-ci.yml
@@ -13,7 +13,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: icr.io/goldeneye_images/goldeneye-ci-image@sha256:stable
+      image: icr.io/goldeneye_images/goldeneye-ci-image:stable
       env:
         TF_VAR_ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
         IC_API_KEY: ${{ secrets.IBMCLOUD_API_KEY }}
@@ -57,7 +57,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: icr.io/goldeneye_images/goldeneye-ci-image@sha256:stable
+      image: icr.io/goldeneye_images/goldeneye-ci-image:stable
       env:
         TF_VAR_ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
         IC_API_KEY: ${{ secrets.IBMCLOUD_API_KEY }}

--- a/.github/workflows/common-terraform-module-ci.yml
+++ b/.github/workflows/common-terraform-module-ci.yml
@@ -36,7 +36,7 @@ jobs:
           # Setup environment since GHA does not run the containers entrypoint
           . /root/.bashrc
           . /root/.profile
-          make
+          make dependency-install-darwin-linux
 
       # Check for pre-commit updates if it is a renovate PR
       - name: Renovate sweeper
@@ -81,7 +81,7 @@ jobs:
           # Setup environment since GHA does not run the containers entrypoint
           . /root/.bashrc
           . /root/.profile
-          make
+          make dependency-install-darwin-linux
 
       # run unit tests
       - name: Unit Tests

--- a/renovate.json
+++ b/renovate.json
@@ -1,19 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>terraform-ibm-modules/common-dev-assets:commonRenovateConfig"],
-  "regexManagers": [
-    {
-      "fileMatch": ["^.github/workflows/.*.yml$"],
-      "matchStrings": ["\\s+image: (?<depName>.*?)(?::(?<currentValue>.*?))?@(?<currentDigest>sha256:[a-f0-9]+)\\s"],
-      "datasourceTemplate": "docker"
-    }
-  ],
-  "packageRules": [
-    {
-      "description": "Only bump the docker image sha once a week, meaning we will only release a new version of common-pipeline-assets once a week (timezone UTC). Without this schedule, it would create daily releases, which is overkill.",
-      "matchDatasources": ["docker"],
-      "schedule": ["before 1pm on Monday"],
-      "semanticCommitType": "fix"
-    }
-  ]
+  "extends": ["local>terraform-ibm-modules/common-dev-assets:commonRenovateConfig"]
 }


### PR DESCRIPTION
### Description

- feat: install exact dependency versions during common pipeline execution
- I also updated to use `stable` image tag. I don't think we need to lock into an exact image sha anymore because we overwrite the dependency versions with the `make` command anyway.
- The make command is taking ~23 seconds to run so not a big overhead

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [x] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
