### PR TITLE
fix: bug in checkout

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -2,6 +2,10 @@
 on:
   workflow_call:
     inputs:
+      checkout_commit:
+        description: Commit ID you want to checkout
+        type: string
+        required: true
       make_command:
         description: Make command to run eg. pre-commit-no-terraform, pre-commit. Default pre-commit
         type: string
@@ -33,6 +37,7 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
           submodules: true
+          ref: ${{ inputs.checkout_commit }}
 
       # Workaround for https://github.com/actions/runner/issues/2033
       - name: Set ownership

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,22 +9,11 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   start-pipeline:
-    # Only start if the run pipeline was posted by a collaborator
-    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/run pipeline' && github.event.comment.author_association=='CONTRIBUTOR' }}
-    name: Get Commit ID
-    runs-on: ubuntu-latest
-    outputs:
-      commit_id: ${{ steps.commit_id.outputs.COMMIT_ID }}
-    steps:
-      - name: Get Latest Commit ID
-        id: commit_id
-        run: |
-          pull_request_url=$(jq -r ".issue.pull_request.url" "$GITHUB_EVENT_PATH")
-          commit_id=$(curl -s -H "Authorization: Bearer ${{ github.token }}" \
-            --retry 3 \
-            "$pull_request_url" \
-            | jq -r ".head.sha")
-          echo "COMMIT_ID=$commit_id" >> "$GITHUB_OUTPUT"
+    # Only start if the issue contains the lable ok-to-test and the run pipeline was posted by a collaborator
+    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/run pipeline' && github.event.comment.author_association=='CONTRIBUTOR' && contains(github.event.issue.labels.*.name, 'ok-to-test') }}
+    uses: ./.github/workflows/get-latest-commit-id.yml
+    with:
+      github_token: ${{ github.token }}
 
   set-commit-status-ci-running:
     uses: ./.github/workflows/set-commit-status.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   start-pipeline:
-    # Only start if the issue contains the lable ok-to-test and the run pipeline was posted by a collaborator
-    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/run pipeline' && github.event.comment.author_association=='CONTRIBUTOR' && contains(github.event.issue.labels.*.name, 'ok-to-test') }}
+    # Only start if the run pipeline was posted by a collaborator
+    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/run pipeline' && github.event.comment.author_association=='CONTRIBUTOR' }}
     uses: ./.github/workflows/get-latest-commit-id.yml
     with:
       github_token: ${{ github.token }}

--- a/.github/workflows/common-golang-ci.yml
+++ b/.github/workflows/common-golang-ci.yml
@@ -6,22 +6,11 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   start-pipeline:
-    # Only start if the run pipeline was posted by a collaborator
-    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/run pipeline' && github.event.comment.author_association=='CONTRIBUTOR' }}
-    name: Get Commit ID
-    runs-on: ubuntu-latest
-    outputs:
-      commit_id: ${{ steps.commit_id.outputs.COMMIT_ID }}
-    steps:
-      - name: Get Latest Commit ID
-        id: commit_id
-        run: |
-          pull_request_url=$(jq -r ".issue.pull_request.url" "$GITHUB_EVENT_PATH")
-          commit_id=$(curl -s -H "Authorization: Bearer ${{ github.token }}" \
-            --retry 3 \
-            "$pull_request_url" \
-            | jq -r ".head.sha")
-          echo "COMMIT_ID=$commit_id" >> "$GITHUB_OUTPUT"
+    # Only start if the issue contains the lable ok-to-test and the run pipeline was posted by a collaborator
+    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/run pipeline' && github.event.comment.author_association=='CONTRIBUTOR' && contains(github.event.issue.labels.*.name, 'ok-to-test') }}
+    uses: ./.github/workflows/get-latest-commit-id.yml
+    with:
+      github_token: ${{ github.token }}
 
   set-commit-status-ci-running:
     uses: ./.github/workflows/set-commit-status.yml
@@ -31,14 +20,16 @@ jobs:
       state: "pending"
       description: "Running"
       context: "CI Pipeline"
-      sha: ${{needs.start-pipeline.outputs.commit_id}}
+      sha: ${{ needs.start-pipeline.outputs.commit_id }}
       target_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       github_repository: ${{ github.repository }}
 
   trigger_ci:
+    needs: [ start-pipeline ]
     uses: ./.github/workflows/ci-pipeline.yml
     secrets: inherit
     with:
+      checkout_commit: ${{ needs.start-pipeline.outputs.commit_id }}
       make_command: pre-commit-no-terraform
       make_test_command: run-go-module-tests
 
@@ -55,18 +46,18 @@ jobs:
       target_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       github_repository: ${{ github.repository }}
 
-    set-commit-status-ci-failure:
-      needs: [ start-pipeline, trigger_ci ]
-      if: ${{ failure() }}
-      uses: ./.github/workflows/set-commit-status.yml
-      with:
-        github_token: ${{ github.token }}
-        state: "failure"
-        description: "Complete - Failure"
-        context: "CI Pipeline"
-        sha: ${{ needs.start-pipeline.outputs.commit_id }}
-        target_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        github_repository: ${{ github.repository }}
+  set-commit-status-ci-failure:
+    needs: [ start-pipeline, trigger_ci ]
+    if: ${{ failure() }}
+    uses: ./.github/workflows/set-commit-status.yml
+    with:
+      github_token: ${{ github.token }}
+      state: "failure"
+      description: "Complete - Failure"
+      context: "CI Pipeline"
+      sha: ${{ needs.start-pipeline.outputs.commit_id }}
+      target_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      github_repository: ${{ github.repository }}
 
-    notify_contributor_and_label_required:
-      uses: ./.github/workflows/post-usage.yml
+  notify_contributor_and_label_required:
+    uses: ./.github/workflows/post-usage.yml

--- a/.github/workflows/common-golang-ci.yml
+++ b/.github/workflows/common-golang-ci.yml
@@ -6,8 +6,8 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   start-pipeline:
-    # Only start if the issue contains the lable ok-to-test and the run pipeline was posted by a collaborator
-    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/run pipeline' && github.event.comment.author_association=='CONTRIBUTOR' && contains(github.event.issue.labels.*.name, 'ok-to-test') }}
+    # Only start if the run pipeline was posted by a collaborator
+    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/run pipeline' && github.event.comment.author_association=='CONTRIBUTOR'}}
     uses: ./.github/workflows/get-latest-commit-id.yml
     with:
       github_token: ${{ github.token }}

--- a/.github/workflows/common-terraform-module-ci-v2.yml
+++ b/.github/workflows/common-terraform-module-ci-v2.yml
@@ -42,8 +42,8 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   start-pipeline:
-    # Only start if the issue contains the lable ok-to-test and the run pipeline was posted by a collaborator
-    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/run pipeline' && github.event.comment.author_association=='CONTRIBUTOR' && contains(github.event.issue.labels.*.name, 'ok-to-test') }}
+    # Only start if the run pipeline was posted by a collaborator
+    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/run pipeline' && github.event.comment.author_association=='CONTRIBUTOR' }}
     uses: ./.github/workflows/get-latest-commit-id.yml
     with:
       github_token: ${{ github.token }}

--- a/.github/workflows/common-terraform-module-ci-v2.yml
+++ b/.github/workflows/common-terraform-module-ci-v2.yml
@@ -42,22 +42,11 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   start-pipeline:
-    # Only start if the run pipeline was posted by a collaborator
-    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/run pipeline' && github.event.comment.author_association=='CONTRIBUTOR' }}
-    name: Get Commit ID
-    runs-on: ubuntu-latest
-    outputs:
-      commit_id: ${{ steps.commit_id.outputs.COMMIT_ID }}
-    steps:
-      - name: Get Latest Commit ID
-        id: commit_id
-        run: |
-          pull_request_url=$(jq -r ".issue.pull_request.url" "$GITHUB_EVENT_PATH")
-          commit_id=$(curl -s -H "Authorization: Bearer ${{ github.token }}" \
-            --retry 3 \
-            "$pull_request_url" \
-            | jq -r ".head.sha")
-          echo "COMMIT_ID=$commit_id" >> "$GITHUB_OUTPUT"
+    # Only start if the issue contains the lable ok-to-test and the run pipeline was posted by a collaborator
+    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/run pipeline' && github.event.comment.author_association=='CONTRIBUTOR' && contains(github.event.issue.labels.*.name, 'ok-to-test') }}
+    uses: ./.github/workflows/get-latest-commit-id.yml
+    with:
+      github_token: ${{ github.token }}
 
   set-commit-status-ci-running:
     uses: ./.github/workflows/set-commit-status.yml
@@ -84,17 +73,19 @@ jobs:
       github_repository: ${{ github.repository }}
 
   trigger_ci:
-    needs: [set-commit-status-ci-running, set-commit-status-infra-running]
+    needs: [start-pipeline, set-commit-status-ci-running, set-commit-status-infra-running]
     uses: ./.github/workflows/ci-pipeline.yml
     secrets: inherit
     with:
+      checkout_commit: ${{ needs.start-pipeline.outputs.commit_id }}
       make_test_command: run-test
 
   trigger_infra_tests:
-    needs: [trigger_ci]
+    needs: [start-pipeline, trigger_ci]
     secrets: inherit
     uses: ./.github/workflows/terraform-test-pipeline.yml
     with:
+      checkout_commit: ${{ needs.start-pipeline.outputs.commit_id }}
       craTarget: ${{ inputs.craTarget }}
       craGoalIgnoreFile: ${{ inputs.craGoalIgnoreFile }}
       craRuleIgnoreFile: ${{ inputs.craRuleIgnoreFile }}

--- a/.github/workflows/common-terraform-module-ci.yml
+++ b/.github/workflows/common-terraform-module-ci.yml
@@ -42,15 +42,19 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   trigger_ci:
+    needs: [ start-pipeline ]
     uses: ./.github/workflows/ci-pipeline.yml
     secrets: inherit
     with:
+      checkout_commit: ${{ needs.start-pipeline.outputs.commit_id }}
       make_test_command: run-test
 
   trigger_infra_tests:
+    needs:  [ start-pipeline ]
     uses: ./.github/workflows/terraform-test-pipeline.yml
     secrets: inherit
     with:
+      checkout_commit: ${{ needs.start-pipeline.outputs.commit_id }}
       craTarget: ${{ inputs.craTarget }}
       craGoalIgnoreFile: ${{ inputs.craGoalIgnoreFile }}
       craRuleIgnoreFile: ${{ inputs.craRuleIgnoreFile }}

--- a/.github/workflows/get-latest-commit-id.yml
+++ b/.github/workflows/get-latest-commit-id.yml
@@ -1,0 +1,27 @@
+on:
+  workflow_call:
+    inputs:
+      github_token:
+        description: 'Personal access token used to authenticate with the GitHub API. Defaults to pipeline token'
+        required: false
+        type: string
+    outputs:
+      commit_id:
+        description: "The latest commit id"
+        value: ${{ jobs.get-commit-id.outputs.commit_id }}
+
+jobs:
+  get-commit-id:
+    runs-on: ubuntu-latest
+    outputs:
+      commit_id: ${{ steps.commit_id.outputs.COMMIT_ID }}
+    steps:
+      - name: Get Latest Commit ID
+        id: commit_id
+        run: |
+          pull_request_url=$(jq -r ".issue.pull_request.url" "$GITHUB_EVENT_PATH")
+          commit_id=$(curl -s -H "Authorization: Bearer ${{ github.token }}" \
+            --retry 3 \
+            "$pull_request_url" \
+            | jq -r ".head.sha")
+          echo "COMMIT_ID=$commit_id" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/terraform-test-pipeline.yml
+++ b/.github/workflows/terraform-test-pipeline.yml
@@ -2,6 +2,10 @@
 on:
   workflow_call:
     inputs:
+      checkout_commit:
+        description: Commit ID you want to checkout
+        type: string
+        required: true
       craTarget:
         type: string
         description: "Target directory for CRA scan(accepts comma seperated list for multiple scans). If not provided CRA Scan will not be run"
@@ -65,6 +69,7 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
           submodules: true
+          ref: ${{ inputs.checkout_commit }}
           # Clone all branches and history. This is needed for the upgrade tests
           fetch-depth: 0
 

--- a/.github/workflows/terraform-test-pipeline.yml
+++ b/.github/workflows/terraform-test-pipeline.yml
@@ -48,8 +48,6 @@ jobs:
   Infrastructure_Tests:
     name: Infrastructure Test
     runs-on: ubuntu-latest
-    # Don't run job on draft PRs
-    #    if: github.event.pull_request.draft == false  # TODO: Enable after consuming pipelines have been updated
     defaults:
       run:
         shell: bash

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-05-11T10:47:21Z",
+  "generated_at": "2023-05-11T13:28:00Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -93,6 +93,16 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 30,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    ".github/workflows/terraform-test-pipeline.yml": [
+      {
+        "hashed_secret": "3b5bf5f75003778663c521c8c35ad277227dd4f5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 29,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-05-11T13:28:00Z",
+  "generated_at": "2023-05-11T14:59:12Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -102,7 +102,7 @@
         "hashed_secret": "3b5bf5f75003778663c521c8c35ad277227dd4f5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
+        "line_number": 33,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ For example, here's how the `common-terraform-module-ci` workflow is called in t
 ```yaml
 jobs:
   call-terraform-ci-pipeline:
-    uses: terraform-ibm-modules/common-pipeline-assets/.github/workflows/common-terraform-module-ci.yml@v1.0.0
+    uses: terraform-ibm-modules/common-pipeline-assets/.github/workflows/common-terraform-module-ci.yml@v1.11.1
     secrets: inherit
 ```


### PR DESCRIPTION
### Description

Bug in the checkout, because we do not trigger from PR commits anymore the default checkout behaviour is to checkout main. The fix is to specify the ref on checkout

### Types of changes in this PR

#### Changes that affect the core Terraform module or submodules
- [ ] Bug fix
- [ ] New feature
- [ ] Dependency update

#### Changes that don't affect the core Terraform module or submodules
- [ ] Examples or tests (addition or updates of examples or tests)
- [x] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other

#### Release required?
Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning).

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version. 

Your notes helps the merger write the commit message for the PR that is published in the release notes for the module.

---

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
