### PR TITLE
install deps b4 precommit

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -15,6 +15,11 @@ on:
         description: Make test command to run eg. run-test, run-go-module-tests. Skip if this is not set
         type: string
         required: false
+      tf_switch_dir:
+        description: Specify the location of a .tf file with the terraform constraint defined to automatically download the latest terraform version in the defined range. Defaults to the repos root level.
+        type: string
+        default: "."
+        required: false
 
 jobs:
   CI_Pipeline:
@@ -44,11 +49,12 @@ jobs:
         run: |
           chown -R $(id -u):$(id -g) $PWD
 
-      # Setup tools
-      - name: Setup tools
+      # Install dependencies
+      - name: Install dependencies
+        env:
+          TFSWITCH_DIRECTORY: ${{ inputs.tf_switch_dir }}
         run: |
-          pip install pre-commit
-          pre-commit install
+          make dependency-install-darwin-linux
 
       # run pre-commit against all files
       - name: Pre-commit

--- a/.github/workflows/common-terraform-module-ci-v2.yml
+++ b/.github/workflows/common-terraform-module-ci-v2.yml
@@ -98,6 +98,7 @@ jobs:
     with:
       checkout_commit: ${{ needs.start-pipeline.outputs.commit_id }}
       make_test_command: run-tests
+      tf_switch_dir: ${{ inputs.tfswitchDir }}
 
   trigger_infra_tests:
     needs: [start-pipeline, trigger_ci]

--- a/.github/workflows/terraform-test-pipeline.md
+++ b/.github/workflows/terraform-test-pipeline.md
@@ -25,6 +25,7 @@ To use this action in your GitHub workflow, you will need to provide input param
 | `sccRegion`               | The region in which the SCC instance is in.                                                                                      | No       | "us-south"                             |
 | `profileID`               | The Profile ID input for CRA SCC v2. Ensure to use a US-specific ID.                                                             | No       | "262b5a6d-9dea-400e-b61f-0fbd63883f78" |
 | `craEnvironmentVariables` | An optional list of environment variables for CRA in the format 'VAR1=value1,VAR2=value2'. Useful for providing TF_VARs.         | No       |                                        |
+| `tfswitchDir` | Specify the location of a .tf file with the terraform constraint defined to automatically download the latest terraform version in the defined range.   | No       |  Defaults to the repos root level (aka ".")                                      |
 | `GITHUB_BASE_REF`         | The target branch merging into.                                                                                                  | Yes      |                                        |
 | `GITHUB_HEAD_REF`         | The source branch coming from.                                                                                                   | Yes      |                                        |
 


### PR DESCRIPTION
### Description

Fix for the following issue:

> HA pipeline is not install dependencies before running pre-commit meaning its using the versions of the deps that come with the docker image, instead of the ones coming from the common-dev-assets revision in the given repo

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
