### PR TITLE
Remove secrets.IBMCLOUD_API_KEY_GEStaging

### DIFF
--- a/.github/workflows/terraform-test-pipeline.md
+++ b/.github/workflows/terraform-test-pipeline.md
@@ -50,7 +50,6 @@ The action uses several secrets that need to be configured at the ORG level:
 | `IBMCLOUD_API_KEY`     | IBM Cloud API Key.                         |
 | `IAC_GE_OPS_TOOLCHAIN_ID`| Toolchain ID for the IBM Cloud.            |
 | `MZ_INGESTION_KEY`     | Ingestion key for Mezmo Logs.              |
-| `IBMCLOUD_API_KEY_GEStaging`| IBM Cloud API key for staging environment. |
 
 ## CRA Config YAML
 The CRA Config YAML provides a more flexible and comprehensive way to specify the configuration for CRA scans. If this YAML file is provided, the corresponding sections of the YAML file will override the relevant input parameters, allowing for more customized scans.

--- a/.github/workflows/terraform-test-pipeline.yml
+++ b/.github/workflows/terraform-test-pipeline.yml
@@ -78,7 +78,6 @@ jobs:
         IC_API_KEY: ${{ secrets.IBMCLOUD_API_KEY }}
         TOOLCHAIN_ID: ${{ secrets.IAC_GE_OPS_TOOLCHAIN_ID }}
         MZ_INGESTION_KEY: ${{ secrets.MZ_INGESTION_KEY }}
-        TF_VAR_ibmcloud_api_key_ext: ${{ secrets.IBMCLOUD_API_KEY_GEStaging }}
         PROFILE_ID: ${{ inputs.profileID }}
         SCC_INSTANCE_ID: ${{ inputs.instanceID }}
         SCC_REGION: ${{ inputs.sccRegion }}


### PR DESCRIPTION
### Description

The `GEStaging` account has been deleted, and so has the actions secret. Removing all references to it in the pipeline code

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
