### PR TITLE
Move Pipeline Failure Notifications to Separate Workflow

### DIFF
--- a/.github/workflows/common-release.yml
+++ b/.github/workflows/common-release.yml
@@ -87,28 +87,26 @@ jobs:
       - name: Create Issue on Failed workflow
         if: ${{ failure() }}
         run: |
-          if curl -sL --fail\
+          response=$(curl -sL \
               -X POST \
               -H "Accept: application/vnd.github.v3+json" \
               -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               https://api.github.com/repos/${{ github.repository }}/issues \
-              -d '{"title":"Release Pipeline failed","body":"For details see: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}","labels":["bug"]}' \
-              -o /dev/null; then
+              -d '{"title":"Release Pipeline failed","body":"For details see: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}","labels":["bug"]}')
+          url=$(echo "$response" | jq -r '.url')
+          if [ ! -z "$url" ]; then
               echo "Issue successfully created"
+              notification_text=":ibm-warning-filled: Release Pipeline failed. For details see: $url."
+              if curl -s -X POST \
+                      -H 'Content-type: application/json' \
+                      -d '{"text":"'"$notification_text"'"}' \
+                      ${{ secrets.GE_SLACK_WEBHOOK_URL }} \
+                      -o /dev/null; then
+                  echo "Slack message successfully created"
+              else
+                  echo "Slack message creation failed"
+              fi
           else
               echo "Issue creation failed"
-          fi
-
-      - name: Create Slack Message on Failed Workflow
-        if: ${{ failure() }}
-        run: |
-          notification_text=":ibm-warning-filled: Release Pipeline failed. For details see: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}."
-          if curl -X POST \
-                  -H 'Content-type: application/json' \
-                  -d '{"text":"'"$notification_text"'"}' \
-                  ${{ secrets.GE_SLACK_WEBHOOK_URL }}; then
-              echo "Slack message successfully created"
-          else
-              echo "Slack message creation failed"
           fi

--- a/.github/workflows/common-release.yml
+++ b/.github/workflows/common-release.yml
@@ -83,7 +83,7 @@ jobs:
             export GIT_COMMITTER_DATE="$(git log -1 --format=%aD ${{ inputs.versionPrefix }}${SEMVER_VERSION})"
             git push origin "${{ inputs.versionPrefix }}${SEMVER_VERSION}" -f
           fi
-  
+
       - name: Create Issue on Failed workflow
         if: ${{ failure() }}
         run: |

--- a/.github/workflows/common-release.yml
+++ b/.github/workflows/common-release.yml
@@ -84,29 +84,8 @@ jobs:
             git push origin "${{ inputs.versionPrefix }}${SEMVER_VERSION}" -f
           fi
 
-      - name: Failure Alert
-        if: ${{ failure() }}
-        run: |
-          response=$(curl -sL \
-              -X POST \
-              -H "Accept: application/vnd.github.v3+json" \
-              -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              https://api.github.com/repos/${{ github.repository }}/issues \
-              -d '{"title":"Release Pipeline failed","body":"For details see: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}","labels":["ci-failure"]}')
-          url=$(echo "$response" | jq -r '.url')
-          if [ ! -z "$url" ]; then
-              echo "Issue successfully created"
-              notification_text=":ibm-warning-filled: Release Pipeline failed. For details see: $url."
-              if curl -s -X POST \
-                      -H 'Content-type: application/json' \
-                      -d '{"text":"'"$notification_text"'"}' \
-                      ${{ secrets.GE_SLACK_WEBHOOK_URL }} \
-                      -o /dev/null; then
-                  echo "Slack message successfully created"
-              else
-                  echo "Slack message creation failed"
-              fi
-          else
-              echo "Issue creation failed"
-          fi
+  create-failure-notifications:
+    needs: [ Semantic_Release ]
+    uses: ./.github/workflows/create-gh-issue-and-slack-message.yml
+    if: ${{ failure() }}
+    secrets: inherit

--- a/.github/workflows/common-release.yml
+++ b/.github/workflows/common-release.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           if curl -sL --fail\
               -X POST \
-              -H "Accept: application/vnd.github+json" \
+              -H "Accept: application/vnd.github.v3+json" \
               -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               https://api.github.com/repos/${{ github.repository }}/issues \
@@ -98,4 +98,17 @@ jobs:
               echo "Issue successfully created"
           else
               echo "Issue creation failed"
+          fi
+
+      - name: Create Slack Message on Failed Workflow
+        if: ${{ failure() }}
+        run: |
+          notification_text=":ibm-warning-filled: Release Pipeline failed. For details see: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}."
+          if curl -X POST \
+                  -H 'Content-type: application/json' \
+                  -d '{"text":"'"$notification_text"'"}' \
+                  ${{ secrets.GE_SLACK_WEBHOOK_URL }}; then
+              echo "Slack message successfully created"
+          else
+              echo "Slack message creation failed"
           fi

--- a/.github/workflows/common-release.yml
+++ b/.github/workflows/common-release.yml
@@ -83,3 +83,19 @@ jobs:
             export GIT_COMMITTER_DATE="$(git log -1 --format=%aD ${{ inputs.versionPrefix }}${SEMVER_VERSION})"
             git push origin "${{ inputs.versionPrefix }}${SEMVER_VERSION}" -f
           fi
+  
+      - name: Create Issue on Failed workflow
+        if: ${{ failure() }}
+        run: |
+          if curl -sL --fail\
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/${{ github.repository }}/issues \
+              -d '{"title":"Release Pipeline failed","body":"For details see: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}","labels":["bug"]}' \
+              -o /dev/null; then
+              echo "Issue successfully created"
+          else
+              echo "Issue creation failed"
+          fi

--- a/.github/workflows/common-release.yml
+++ b/.github/workflows/common-release.yml
@@ -93,7 +93,7 @@ jobs:
               -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               https://api.github.com/repos/${{ github.repository }}/issues \
-              -d '{"title":"Release Pipeline failed","body":"For details see: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}","labels":["bug"]}')
+              -d '{"title":"Release Pipeline failed","body":"For details see: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}","labels":["ci-failure"]}')
           url=$(echo "$response" | jq -r '.url')
           if [ ! -z "$url" ]; then
               echo "Issue successfully created"

--- a/.github/workflows/common-release.yml
+++ b/.github/workflows/common-release.yml
@@ -84,7 +84,7 @@ jobs:
             git push origin "${{ inputs.versionPrefix }}${SEMVER_VERSION}" -f
           fi
 
-      - name: Create Issue on Failed workflow
+      - name: Failure Alert
         if: ${{ failure() }}
         run: |
           response=$(curl -sL \

--- a/.github/workflows/create-gh-issue-and-slack-message.yml
+++ b/.github/workflows/create-gh-issue-and-slack-message.yml
@@ -21,9 +21,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
-
       - name: Create Github and Slack notifications
         run: |
           response=$(curl -sL \

--- a/.github/workflows/create-gh-issue-and-slack-message.yml
+++ b/.github/workflows/create-gh-issue-and-slack-message.yml
@@ -4,6 +4,17 @@ name: Create-Notifications
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_call:
+    inputs:
+      issue_title:
+        description: 'Title for the issue created about the failure'
+        required: false
+        type: string
+        default: 'Release Pipeline failed'
+      labels:
+        description: 'Labels applied to the issue created'
+        required: false
+        type: string
+        default: '"ci-pipeline"'
 
 jobs:
   Create-Notifications:
@@ -21,9 +32,9 @@ jobs:
               -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               https://api.github.com/repos/${{ github.repository }}/issues \
-              -d '{"title":"Release Pipeline failed","body":"For details see: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}","labels":["ci-failure"]}')
-          url=$(echo "$response" | jq -r '.url')
-          if [ ! -z "$url" ]; then
+              -d '{"title":"${{ inputs.issue_title }}","body":"For details see: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}","labels":[${{ inputs.labels }}]}')
+          url=$(echo "$response" | jq -r '.html_url')
+          if [ ! -z "$url" ] && [ "$url" != "null" ]; then
               echo "Issue successfully created"
               notification_text=":ibm-warning-filled: Release Pipeline failed. For details see: $url."
               if curl -s -X POST \

--- a/.github/workflows/create-gh-issue-and-slack-message.yml
+++ b/.github/workflows/create-gh-issue-and-slack-message.yml
@@ -1,0 +1,40 @@
+name: Create-Notifications
+
+# Controls when the workflow will run
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  Create-Notifications:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      - name: Create Github and Slack notifications
+        run: |
+          response=$(curl -sL \
+              -X POST \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/${{ github.repository }}/issues \
+              -d '{"title":"Release Pipeline failed","body":"For details see: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}","labels":["ci-failure"]}')
+          url=$(echo "$response" | jq -r '.url')
+          if [ ! -z "$url" ]; then
+              echo "Issue successfully created"
+              notification_text=":ibm-warning-filled: Release Pipeline failed. For details see: $url."
+              if curl -s -X POST \
+                      -H 'Content-type: application/json' \
+                      -d '{"text":"'"$notification_text"'"}' \
+                      ${{ secrets.GE_SLACK_WEBHOOK_URL }} \
+                      -o /dev/null; then
+                  echo "Slack message successfully created"
+              else
+                  echo "Slack message creation failed"
+              fi
+          else
+              echo "Issue creation failed"
+          fi

--- a/.github/workflows/create-gh-issue-and-slack-message.yml
+++ b/.github/workflows/create-gh-issue-and-slack-message.yml
@@ -3,7 +3,7 @@ name: Create-Notifications
 # Controls when the workflow will run
 on:
   # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   Create-Notifications:


### PR DESCRIPTION
### Description

The notifications to create an issue and a slack notification have been moved to their own github actions workflow. The Semantic release pipeline has been updated to use this workflow.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
