### PR TITLE
fix: pipeline fail git issue now has repo and date in title

### DIFF
--- a/.github/workflows/create-gh-issue-and-slack-message.yml
+++ b/.github/workflows/create-gh-issue-and-slack-message.yml
@@ -23,13 +23,14 @@ jobs:
     steps:
       - name: Create Github and Slack notifications
         run: |
+          current_date=$(date +"%D")
           response=$(curl -sL \
               -X POST \
               -H "Accept: application/vnd.github.v3+json" \
               -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               https://api.github.com/repos/${{ github.repository }}/issues \
-              -d '{"title":"${{ inputs.issue_title }}","body":"For details see: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}","labels":[${{ inputs.labels }}]}')
+              -d '{"title":"[${{ github.repository }}] ${{ inputs.issue_title }} '"$current_date"'","body":"For details see: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}","labels":[${{ inputs.labels }}]}')
           url=$(echo "$response" | jq -r '.html_url')
           if [ ! -z "$url" ] && [ "$url" != "null" ]; then
               echo "Issue successfully created"


### PR DESCRIPTION
### Description

Now the title includes the repo and the date on which the failure happened.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
