### PR TITLE
Permissions Fix for Pages Release

### DIFF
--- a/.github/workflows/pages-release.yml
+++ b/.github/workflows/pages-release.yml
@@ -39,6 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: Build
 
+    permissions:
+      id-token: write
+      pages: write
+
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/pages-release.yml
+++ b/.github/workflows/pages-release.yml
@@ -2,18 +2,6 @@ name: Github Pages Release
 
 on:
   workflow_call:
-    inputs:
-      versionPrefix:
-        required: false
-        type: string
-        description: "Optional prefix to add before version number"
-        default: "v"
-
-      sign:
-        required: false
-        type: boolean
-        description: "Sign tags"
-        default: true
 
 jobs:
   Build:
@@ -46,64 +34,26 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: './build/'
-  Semantic_Release:
+  Release:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     needs: Build
 
-    env:
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GH_TOKEN }}
-          submodules: true
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Install dependencies
-        run: npm install semantic-release
-          @semantic-release/changelog
-          @semantic-release/exec
-          @semantic-release/git
-          @semantic-release/github
-
       - name: Setup Pages
         uses: actions/configure-pages@v5
-
-      # Release
-      - name: Semantic Release
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          GIT_AUTHOR_NAME: "terraform-ibm-modules-ops"
-          GIT_AUTHOR_EMAIL: "Terraform.IBM.Modules.Operations@ibm.com"
-          GIT_COMMITTER_NAME: "terraform-ibm-modules-ops"
-          GIT_COMMITTER_EMAIL: "Terraform.IBM.Modules.Operations@ibm.com"
-        run: |
-          if [ ! -e "./package-lock.json" ]; then ln -s /tmp/package-lock.json package-lock.json; fi
-          if [ ! -d "./node_modules" ]; then ln -s /tmp/node_modules node_modules; fi
-          npx semantic-release
-          echo "Release complete"
 
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
 
-      - id: versionNumber
-        run: |
-          echo "version=$SEMVER_VERSION"
-          echo "version=$SEMVER_VERSION" >> "$GITHUB_OUTPUT"
-
   create-failure-notifications:
-    needs: [ Semantic_Release ]
+    needs: [ Release ]
     uses: ./.github/workflows/create-gh-issue-and-slack-message.yml
     if: ${{ failure() }}
     secrets: inherit

--- a/.github/workflows/pages-release.yml
+++ b/.github/workflows/pages-release.yml
@@ -1,0 +1,109 @@
+name: Github Pages Release
+
+on:
+  workflow_call:
+    inputs:
+      versionPrefix:
+        required: false
+        type: string
+        description: "Optional prefix to add before version number"
+        default: "v"
+
+      sign:
+        required: false
+        type: boolean
+        description: "Sign tags"
+        default: true
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Cache dependencies
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ./node_modules
+            ./client/node_modules
+          key: modules-${{ hashFiles('package-lock.json') }}
+      - name: npm install
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          make clean-npm
+      - name: npm test
+        run: |
+          npm test
+      - name: npm build
+        run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './build/'
+  Semantic_Release:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    needs: Build
+
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          submodules: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install semantic-release
+          @semantic-release/changelog
+          @semantic-release/exec
+          @semantic-release/git
+          @semantic-release/github
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      # Release
+      - name: Semantic Release
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GIT_AUTHOR_NAME: "terraform-ibm-modules-ops"
+          GIT_AUTHOR_EMAIL: "Terraform.IBM.Modules.Operations@ibm.com"
+          GIT_COMMITTER_NAME: "terraform-ibm-modules-ops"
+          GIT_COMMITTER_EMAIL: "Terraform.IBM.Modules.Operations@ibm.com"
+        run: |
+          if [ ! -e "./package-lock.json" ]; then ln -s /tmp/package-lock.json package-lock.json; fi
+          if [ ! -d "./node_modules" ]; then ln -s /tmp/node_modules node_modules; fi
+          npx semantic-release
+          echo "Release complete"
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+      - id: versionNumber
+        run: |
+          echo "version=$SEMVER_VERSION"
+          echo "version=$SEMVER_VERSION" >> "$GITHUB_OUTPUT"
+
+  create-failure-notifications:
+    needs: [ Semantic_Release ]
+    uses: ./.github/workflows/create-gh-issue-and-slack-message.yml
+    if: ${{ failure() }}
+    secrets: inherit


### PR DESCRIPTION
### Description

Set permissions needed to release github pages.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
